### PR TITLE
Classpath separator on linux is different from windows

### DIFF
--- a/src/classpath.rs
+++ b/src/classpath.rs
@@ -12,6 +12,12 @@ pub fn should_use_library(lib: &Library) -> bool {
     return is_all_rules_satisfied(rules);
 }
 
+
+#[cfg(target_family = "unix")]
+pub const CLASSPATH_SEP: char = ':';
+#[cfg(target_famliy = "windows")]
+pub const CLASSPATH_SEP: char =  ';';
+
 pub fn create_classpath(
     jar_file: PathBuf,
     libraries_path: PathBuf,
@@ -25,7 +31,7 @@ pub fn create_classpath(
             let artifact = &lib.downloads.artifact;
             let lib_path = artifact.path.clone();
             let fixed_lib_path = Path::new(&libraries_path).join(lib_path.replace("/", "\\"));
-            classpath = format!("{};{}", classpath, fixed_lib_path.to_str().unwrap());
+            classpath = format!("{}{}{}", classpath, CLASSPATH_SEP, fixed_lib_path.to_str().unwrap());
         }
     }
 

--- a/src/classpath.rs
+++ b/src/classpath.rs
@@ -12,11 +12,10 @@ pub fn should_use_library(lib: &Library) -> bool {
     return is_all_rules_satisfied(rules);
 }
 
-
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "windows"))] // Linux and MacOS
 pub const CLASSPATH_SEP: char = ':';
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_os = "windows")] // Windows
 pub const CLASSPATH_SEP: char = ';';
 
 pub fn create_classpath(

--- a/src/classpath.rs
+++ b/src/classpath.rs
@@ -13,10 +13,11 @@ pub fn should_use_library(lib: &Library) -> bool {
 }
 
 
-#[cfg(target_family = "unix")]
+#[cfg(target_os = "linux")]
 pub const CLASSPATH_SEP: char = ':';
-#[cfg(target_famliy = "windows")]
-pub const CLASSPATH_SEP: char =  ';';
+
+#[cfg(not(target_os = "linux"))]
+pub const CLASSPATH_SEP: char = ';';
 
 pub fn create_classpath(
     jar_file: PathBuf,


### PR DESCRIPTION
On Linux systems, the java classpath separator is a colon instead of a semicolon. I have used conditional compilation to set the separator based on the compilation target.